### PR TITLE
Fix broken url support

### DIFF
--- a/slackdown/__init__.py
+++ b/slackdown/__init__.py
@@ -62,16 +62,16 @@ def render(txt):
     """
 
     # Removing links to other channels
-    txt = re.sub(r'<#[^\|]*\|(.*)>', r'#\g<1>', txt)
+    txt = re.sub(r'<#[^\|]*?\|(.*?)>', r'#\g<1>', txt)
 
     # Removing links to other users
-    txt = re.sub(r'<(@.*)>', r'\g<1>', txt)
+    txt = re.sub(r'<(@.*?)>', r'\g<1>', txt)
 
     # handle named hyperlinks
-    txt = re.sub(r'<([^\|]*)\|([^\|]*)>', r'<a href="\g<1>" target="blank">\g<2></a>', txt)
+    txt = re.sub(r'<([^\|]*?)\|([^\|]*?)>', r'<a href="\g<1>" target="blank">\g<2></a>', txt)
 
     # handle unnamed hyperlinks
-    txt = re.sub(r'<([^a|/a].*)>', r'<a href="\g<1>" target="blank">\g<1></a>', txt)
+    txt = re.sub(r'<([^a|/a].*?)>', r'<a href="\g<1>" target="blank">\g<1></a>', txt)
 
     # handle ordered and unordered lists
     for delimeter in LIST_DELIMITERS:


### PR DESCRIPTION
The regex you are using doesn't match a text with two links.  For example, <www.google.com>test> will match test as well. I just make it not greedy and match one link at the time.